### PR TITLE
Remove ability to change the standard of a question

### DIFF
--- a/components/QuestionsTable/QuestionsTable.js
+++ b/components/QuestionsTable/QuestionsTable.js
@@ -36,29 +36,7 @@ const columns = [
     id: 'standard',
     label: 'Standard',
     width: 'auto',
-    render: (edited, row) => {
-      if (edited) {
-        //if this url is being edited then it needs to be an input box
-        //copy all the info about the row being currently edited
-        let buffer = {};
-        editedRow = Object.assign(buffer, row);
-        return (
-          <SelectPicker
-            searchable={false}
-            cleanable={false}
-            defaultValue={editedRow.standards.id}
-            onChange={value => (editedRow.standards.id = value)}
-            data={standards.map(standard => ({
-              label: standard.name,
-              value: standard.id,
-            }))}
-          />
-        );
-      } else {
-        //else just display standards name
-        return <div>{row['standards']['name']}</div>;
-      }
-    },
+    render: (edited, row) => <div>{row['standards']['name']}</div>,
   },
   {
     id: 'url',
@@ -136,7 +114,6 @@ export default function QuestionsTable() {
       body: JSON.stringify({
         body: editedRow['body'],
         url: editedRow['url'],
-        standard: editedRow['standards']['id'],
       }),
     });
     return await res.json();
@@ -286,15 +263,15 @@ export default function QuestionsTable() {
         <div>Add new question</div>
       </Button>
       <CustomTable
-        tableType='questions'
+        tableType="questions"
         data={localData}
         columns={columns}
         editing={editing}
         sendUpdated={() => sendUpdated()}
         cancelEditing={() => cancelEditing()}
-        setEditing={(i) => setEditing(i)}
-        confirmDelete={(id) => confirmDelete(id)}
-        />
+        setEditing={i => setEditing(i)}
+        confirmDelete={id => confirmDelete(id)}
+      />
     </div>
   );
 }

--- a/pages/api/questions/[questionId].js
+++ b/pages/api/questions/[questionId].js
@@ -33,10 +33,12 @@ export default async function handler(req, res) {
       return res.end('The required question details are missing');
     }
 
+    // Note: we don't support changing the standard of a question (otherwise users will
+    // answer the same question but scores will be recorded against different standards,
+    // skewing the results)
     const fields = {};
     if (url) fields.default_url = url;
     if (body) fields.body = body;
-    if (standard) fields.standards = { connect: { id: standard } };
 
     const response = await prisma.questions.update({
       where: { id: +questionId },


### PR DESCRIPTION
If we allow users to change the standard tied to a question, we'll end
up having different users answer the same question, but having their
scores stored against a different standard. When aggregating the data,
this will skew the results and make them less meaningful, so we
shouldn't let admins change the standard for a question.

Closes #57.