### PR TITLE
save users dark mode preference using localStorage

### DIFF
--- a/components/Header/Header.js
+++ b/components/Header/Header.js
@@ -35,6 +35,14 @@ function Header({ session }) {
   };
 
   useEffect(() => {
+
+    //to ensure the right mode that is saved is displayed
+    if (window.localStorage.getItem("dark") === "true") {
+      document.body.classList.toggle("dark-mode", true);
+    } else {
+      document.body.classList.toggle("dark-mode", false);
+    }
+
     const handleClickOutside = event => {
       if (
         mobileMenuRef.current &&
@@ -54,7 +62,14 @@ function Header({ session }) {
   }, [mobileMenuRef, isOpen]);
 
   const toggleDark = () => {
-    document.body.classList.toggle("dark-mode")
+    const wasLight = window.localStorage.getItem("dark") === "false";
+    window.localStorage.setItem("dark", (wasLight ? "true" : "false"));
+    if (wasLight) {
+      document.body.classList.add("dark-mode");
+    }
+    else {
+      document.body.classList.remove("dark-mode");
+    }
   };
 
   return (


### PR DESCRIPTION
Now when a user goes back on the platform after closing window/tab their dark mode preference is saved (thanks for the website hint @shu8)

part of #49 